### PR TITLE
hotfix for issue #7

### DIFF
--- a/hwpc/input_download.py
+++ b/hwpc/input_download.py
@@ -15,6 +15,8 @@ class InputDownload(object):
     def __init__(self) -> None:
         super().__init__()
         self.bucket = os.getenv('GCP_BUCKET')
+        if self.bucket is None:
+            self.bucket = "hwpcarbon-data"
 
     def downloads(self):
         if not os.path.exists('data'):


### PR DESCRIPTION
quickfix for #7 

This should check to see if self.bucket failed to be assigned a value, if it did, it will be given "hwpcarbon-data"