### PR TITLE
updated to dynamically pull from scenarion json or default data

### DIFF
--- a/src/hwpccalc/hwpc/names.py
+++ b/src/hwpccalc/hwpc/names.py
@@ -146,3 +146,4 @@ class Names(singleton.Singleton):
     class Output(singleton.Singleton):
         output_path = ""
         run_name = ""
+        scenario_info = ""

--- a/src/hwpccalc/main.py
+++ b/src/hwpccalc/main.py
@@ -20,7 +20,6 @@ def run(args):
 
     names.Names.Output.output_path = path.replace("inputs", "outputs")
     names.Names.Output.run_name = name
-
     # i = input_download.InputDownload()
     # i.downloads()
     me = hwpccalc.meta_model.MetaModel()
@@ -39,7 +38,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-b", "--bucket", help="Bucket to use for user input", default="hwpc")
-    parser.add_argument("-p", "--path", help="Path to uploaded user data to run on", default="hwpc-user-inputs/20220921-1740")
+    parser.add_argument("-p", "--path", help="Path to uploaded user data to run on", default="d9336900-8516-4a87-8ac8-429f97742f53")
     parser.add_argument("-n", "--name", help="User provided name of simulation run.", default="cali2")
 
     args, _ = parser.parse_known_args()


### PR DESCRIPTION
update for the new scenario json. Now load_data dynamically pulls data down from either hwpc/default-data or hwpc/hpwc-user-inputs/(user_string). This way there is zero data hard saved to the disk, and has it all as pandas dataframes in the ModelData.data dictionary. I also saved the json itself to names.Names.Outputs.scenario_info if we needed to reference any data that is not a csv input, such as the run name or email. 