### PR TITLE
updated hwpc perms on terraform and file upload not public

### DIFF
--- a/FPL-HWPC-web/utils/s3_helper.py
+++ b/FPL-HWPC-web/utils/s3_helper.py
@@ -39,7 +39,7 @@ class S3Helper(object):
 
         try:
             response = S3Helper.s3_client.upload_fileobj(
-                file_name, bucket, object_name, ExtraArgs={"ACL": "public-read"}
+                file_name, bucket, object_name
             )
         except ClientError as e:
             logging.error(e)

--- a/terraform/s3_simple_storage.tf
+++ b/terraform/s3_simple_storage.tf
@@ -22,6 +22,15 @@ resource "aws_s3_bucket" "hwpc" {
   #   hosted_zone_id = "Z3BJ6K6RIION7M"
 }
 
+resource "aws_s3_bucket_public_access_block" "example-public-access-block" {
+  bucket = "hwpc"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket" "hwpc_output" {
   #   arn            = "aws:s3:::hwpc-output"
   bucket = "hwpc-output"

--- a/terraform/s3_simple_storage.tf
+++ b/terraform/s3_simple_storage.tf
@@ -1,9 +1,3 @@
-resource "aws_s3_bucket" "aws_cloudtrail_logs_234659567514_0403b5d3" {
-  #   arn            = "aws:s3:::aws-cloudtrail-logs-234659567514-0403b5d3"
-  bucket = "aws-cloudtrail-logs-234659567514-0403b5d3"
-  #   hosted_zone_id = "Z3BJ6K6RIION7M"
-}
-
 # resource "aws_s3_bucket" "cf_templates_ui1evhwv02nm_us_west_2" {
 #   arn            = "arn:aws:s3:::cf-templates-ui1evhwv02nm-us-west-2"
 #   bucket         = "cf-templates-ui1evhwv02nm-us-west-2"


### PR DESCRIPTION
quickfix to make sure that nothing gets set to public when uploading to our buckets, and setting the bucket's config in terraform to prevent any public acls